### PR TITLE
fixed cursor generation for reexported type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bobflux-gen",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Generator for monkey files in bobflux application.",
   "main": "index.js",
   "repository": {

--- a/spec/cursorsGenerator.spec.ts
+++ b/spec/cursorsGenerator.spec.ts
@@ -804,7 +804,27 @@ export default rootCursor;
             expect(g.createCursorsFilePath('c:/app/state.ts'))
                 .toBe('c:/app/state.cursors.ts');
         });
-    })
+    });
+
+    describe('reExported type', () => {
+        beforeEach(() => {
+            testCase = testCaseRunRecurse(
+                'IApplicationState',
+                './stateWithExternalTypeReExported.ts',
+                'stateWithExternalType'
+            );
+        });
+
+        it('generate curosr with correct state chain for reexported InnerState', done => {
+            testCase.do().then(text => {
+                expect(text).toContain(`
+export const externalTypeReexportedCursor: f.ICursor<ExportType.SomeOtherType.IInnerState> = {
+    key: 'externalTypeReexported'
+};`);
+                done();
+            });
+        });
+    });
 
     function aProject(appStateName: string, appFilePath: string, writeFileCallback: (filename: string, b: Buffer) => void, version: string = 'AVersion'): gb.IGenerationProject {
         return {

--- a/spec/resources/lib.ts
+++ b/spec/resources/lib.ts
@@ -1,0 +1,2 @@
+import * as SomeType from "./inner/innerType";
+export { SomeType as SomeOtherType };

--- a/spec/resources/stateWithExternalTypeReExported.ts
+++ b/spec/resources/stateWithExternalTypeReExported.ts
@@ -1,0 +1,6 @@
+import * as ExportType from "./lib";
+import * as f from "bobflux";
+
+export interface IApplicationState extends f.IState {
+  externalTypeReexported: ExportType.SomeOtherType.IInnerState;
+}

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -100,7 +100,7 @@ export function getExternalAlias(type: string, data: tsa.IStateSourceData, topLe
         {
             prefix: topLevelImports[dep.fullPath].prefix,
             sourceType: typePath[0] === dep.prefix
-                ? typePath[1]
+                ? typePath.slice(1).join('.')
                 : dep.types.find(t => t.targetType === typePath[0]).sourceType
         }
     );


### PR DESCRIPTION
When state field type is a chain with 2 or more subtypes, only first subtype used for cursor generation.